### PR TITLE
chore(`deps`): disable default features for `revm`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy" }
 alloy-rpc-trace-types = { git = "https://github.com/alloy-rs/alloy" }
 
 # revm = "3.4"
-revm = { git = "https://github.com/bluealloy/revm", branch = "reth_freeze" }
+revm = { git = "https://github.com/bluealloy/revm", branch = "reth_freeze", default-features = false, features = ["std"] }
 
 # js-tracing-inspector
 boa_engine = { version = "0.17", optional = true }


### PR DESCRIPTION
By default the `c-kzg` dep on revm is enabled, and we don't need this for the inspectors, so we can disable it.

this also should fix the [release workflow failures for linux](https://github.com/foundry-rs/foundry/actions/runs/7508860860) on foundry.