### PR TITLE
feat: use inspector db directly in js

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,8 +36,6 @@ serde = { version = "1", features = ["derive"] }
 thiserror = { version = "1", optional = true }
 serde_json = { version = "1", optional = true }
 
-tokio = { version = "1", features = ["sync"], optional = true }
-
 [features]
 default = []
-js-tracer = ["boa_engine", "boa_gc", "tokio", "thiserror", "serde_json"]
+js-tracer = ["boa_engine", "boa_gc", "thiserror", "serde_json"]

--- a/src/tracing/js/bindings.rs
+++ b/src/tracing/js/bindings.rs
@@ -738,7 +738,7 @@ impl EvmDbRef {
         // SAFETY:
         //
         // boa requires 'static lifetime for all objects.
-        // As mention in the `Safety` section of [GuardedNullableGc] the caller of this function
+        // As mentioned in the `Safety` section of [GuardedNullableGc] the caller of this function
         // needs to guarantee that the passed-in lifetime is sufficiently long for the lifetime of
         // the guard.
         let db = JsDb(db);

--- a/src/tracing/js/builtins.rs
+++ b/src/tracing/js/builtins.rs
@@ -49,7 +49,13 @@ pub(crate) fn from_buf(val: JsValue, context: &mut Context<'_>) -> JsResult<Vec<
         }
     }
 
-    Err(JsError::from_native(JsNativeError::typ().with_message("invalid buffer type")))
+    if let Some(js_string) = val.as_string().cloned() {
+        return hex_decode_js_string(js_string);
+    }
+
+    Err(JsError::from_native(
+        JsNativeError::typ().with_message(format!("invalid buffer type: {}", val.type_of())),
+    ))
 }
 
 /// Create a new array buffer from the address' bytes.


### PR DESCRIPTION
Closes #6

This gets rid of the additional JS service requirement by transmuting the db reference and guarding it against garbage collection.

This applies a similar transmute hack as `std::thread::scoped` by transmuting the lifetime bound of the DB via a trait object.

The DB wrappers are nullable, once the guard is dropped the actual garbage collected DB reference is also removed