### PR TITLE
test: add decoding test

### DIFF
--- a/src/tracing/utils.rs
+++ b/src/tracing/utils.rs
@@ -73,7 +73,7 @@ pub(crate) fn maybe_revert_reason(output: &[u8]) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_sol_types::{GenericContractError, SolInterface};
+    use alloy_sol_types::{GenericContractError, SolInterface, SolValue};
 
     #[test]
     fn decode_empty_revert() {
@@ -87,5 +87,27 @@ mod tests {
         let encoded = err.abi_encode();
         let reason = maybe_revert_reason(&encoded).unwrap();
         assert_eq!(reason, "my revert");
+    }
+
+    // <https://github.com/Uniswap/v2-periphery/blob/dda62473e2da448bc9cb8f4514dadda4aeede5f4/contracts/libraries/UniswapV2Library.sol#L44>
+    // <https://etherscan.io/tx/0x105707c8e3b3675a8424a7b0820b271cbe394eaf4d5065b03c273298e3a81314>
+    #[test]
+    fn decode_revert_reason_with_error() {
+        let err = hex!("08c379a000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000024556e697377617056323a20494e53554646494349454e545f494e5055545f414d4f554e5400000000000000000000000000000000000000000000000000000080");
+        let reason = maybe_revert_reason(&err[..]);
+
+        // let err = GenericContractError::Revert("UniswapV2Library:
+        // INSUFFICIENT_INPUT_AMOUNT".into()); let encoded = err.abi_encode();
+        //
+        // dbg!(hex::encode(&encoded));
+        //
+        // let s = "UniswapV2Library: INSUFFICIENT_INPUT_AMOUNT";
+        // let encoded = s.abi_encode();
+        // dbg!(hex::encode(&encoded));
+        // dbg!(reason);
+        // let err = GenericContractError::Revert("my revert".into());
+        // let encoded = err.abi_encode();
+        // let reason = maybe_revert_reason(&encoded).unwrap();
+        // assert_eq!(reason, "my revert");
     }
 }


### PR DESCRIPTION
@DaniPopes we're unable to decode the revert reason for the output of this trace:

```json
{
	"jsonrpc":"2.0",
	"method":"debug_traceTransaction",
	"params":["0x105707c8e3b3675a8424a7b0820b271cbe394eaf4d5065b03c273298e3a81314", {  "tracer": "callTracer" }],
	"id":1
}
```

```json
            {
                "from": "0x8ba8ceecdcb00bee67a0e9acc0c23f4ef433857e",
                "gas": "0x6d706",
                "gasUsed": "0x463d2",
                "to": "0xf848e97469538830b0b147152524184a255b9106",
                "input": "0x022c0d9f00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000544d473eab119205930000000000000000000000008ba8ceecdcb00bee67a0e9acc0c23f4ef433857e000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000ac953d1038efbf6000000000000000000000000000000000000000000000000052befe79d2ca1a7d3e000000000000000000000000000000000000000000000054bdde1a19a547ef49",
                "output": "0x08c379a000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000024556e697377617056323a20494e53554646494349454e545f494e5055545f414d4f554e5400000000000000000000000000000000000000000000000000000080",
                "error": "Reverted",
```

erigon decodes the reason

```json
           {
                "output": "0x08c379a000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000024556e697377617056323a20494e53554646494349454e545f494e5055545f414d4f554e5400000000000000000000000000000000000000000000000000000080",
                "error": "execution reverted",
                "revertReason": "UniswapV2: INSUFFICIENT_INPUT_AMOUNT",
```               

looks the like output has a few extra bytes, any ideas?