### PR TITLE
fix: use original value in prestate tracer

### DIFF
--- a/src/tracing/builder/geth.rs
+++ b/src/tracing/builder/geth.rs
@@ -202,7 +202,8 @@ impl GethTraceBuilder {
                     Entry::Occupied(entry) => entry.into_mut(),
                 };
 
-                for (key, value) in node.touched_slots() {
+                // TODO is this even necessary if we only need the changed slots? because all of them should be included in the `account_diffs`
+                for (key, value) in node.touched_slots_original_values() {
                     match acc_state.storage.entry(key.into()) {
                         Entry::Vacant(entry) => {
                             entry.insert(value.into());

--- a/src/tracing/builder/geth.rs
+++ b/src/tracing/builder/geth.rs
@@ -11,7 +11,7 @@ use alloy_rpc_trace_types::geth::{
     GethDefaultTracingOptions, PreStateConfig, PreStateFrame, PreStateMode, StructLog,
 };
 use revm::{db::DatabaseRef, primitives::ResultAndState};
-use std::collections::{btree_map::Entry, BTreeMap, HashMap, VecDeque};
+use std::collections::{BTreeMap, HashMap, VecDeque};
 
 /// A type for creating geth style traces
 #[derive(Clone, Debug)]
@@ -187,62 +187,23 @@ impl GethTraceBuilder {
 
         if prestate_config.is_default_mode() {
             let mut prestate = PreStateMode::default();
-            // in default mode we __only__ return the touched state
-            for node in self.nodes.iter() {
-                let addr = node.trace.address;
-
-                let acc_state = match prestate.0.entry(addr) {
-                    Entry::Vacant(entry) => {
-                        let db_acc = db.basic_ref(addr)?.unwrap_or_default();
-                        let code = load_account_code(&db, &db_acc);
-                        let acc_state =
-                            AccountState::from_account_info(db_acc.nonce, db_acc.balance, code);
-                        entry.insert(acc_state)
-                    }
-                    Entry::Occupied(entry) => entry.into_mut(),
-                };
-
-                // TODO is this even necessary if we only need the changed slots? because all of them should be included in the `account_diffs`
-                for (key, value) in node.touched_slots_original_values() {
-                    match acc_state.storage.entry(key.into()) {
-                        Entry::Vacant(entry) => {
-                            entry.insert(value.into());
-                        }
-                        Entry::Occupied(_) => {
-                            // we've already recorded this slot
-                        }
-                    }
-                }
-            }
-
-            // also need to check changed accounts for things like balance changes etc
+            // we only want changed accounts for things like balance changes etc
             for (addr, changed_acc) in account_diffs {
-                let acc_state = match prestate.0.entry(addr) {
-                    Entry::Vacant(entry) => {
-                        let db_acc = db.basic_ref(addr)?.unwrap_or_default();
-                        let code = load_account_code(&db, &db_acc);
-                        let acc_state =
-                            AccountState::from_account_info(db_acc.nonce, db_acc.balance, code);
-                        entry.insert(acc_state)
-                    }
-                    Entry::Occupied(entry) => {
-                        // already recorded via touched accounts
-                        entry.into_mut()
-                    }
-                };
+                let db_acc = db.basic_ref(addr)?.unwrap_or_default();
+                let code = load_account_code(&db, &db_acc);
+                let mut acc_state =
+                    AccountState::from_account_info(db_acc.nonce, db_acc.balance, code);
 
-                // in case we missed anything during the trace, we need to add the changed accounts
-                // storage
+                // insert the original value of all modified storage slots
                 for (key, slot) in changed_acc.storage.iter() {
-                    match acc_state.storage.entry((*key).into()) {
-                        Entry::Vacant(entry) => {
-                            entry.insert(slot.previous_or_original_value.into());
-                        }
-                        Entry::Occupied(_) => {
-                            // we've already recorded this slot
-                        }
+                    // empty slots are excluded
+                    if slot.previous_or_original_value.is_zero() {
+                        continue;
                     }
+                    acc_state.storage.insert((*key).into(), slot.previous_or_original_value.into());
                 }
+
+                prestate.0.insert(addr, acc_state);
             }
 
             Ok(PreStateFrame::Default(prestate))

--- a/src/tracing/builder/geth.rs
+++ b/src/tracing/builder/geth.rs
@@ -195,7 +195,8 @@ impl GethTraceBuilder {
                     AccountState::from_account_info(db_acc.nonce, db_acc.balance, code);
 
                 // insert the original value of all modified storage slots
-                for (key, slot) in changed_acc.storage.iter() {
+                for (key, slot) in changed_acc.storage.iter().filter(|(_, slot)| slot.is_changed())
+                {
                     // empty slots are excluded
                     if slot.previous_or_original_value.is_zero() {
                         continue;

--- a/src/tracing/types.rs
+++ b/src/tracing/types.rs
@@ -147,18 +147,18 @@ impl CallTraceNode {
         }
     }
 
-    /// Returns all storage slots touched by this trace and the value this storage.
+    /// Returns all storage slots touched by this trace and the original value of this storage.
     ///
     /// A touched slot is either a slot that was written to or read from.
     ///
     /// If the slot is accessed more than once, the result only includes the first time it was
-    /// accessed, in other words in only returns the original value of the slot.
-    pub fn touched_slots(&self) -> BTreeMap<U256, U256> {
+    /// accessed, in other words it only returns the original value of the slot.
+    pub fn touched_slots_original_values(&self) -> BTreeMap<U256, Option<U256>> {
         let mut touched_slots = BTreeMap::new();
         for change in self.trace.steps.iter().filter_map(|s| s.storage_change.as_ref()) {
             match touched_slots.entry(change.key) {
                 std::collections::btree_map::Entry::Vacant(entry) => {
-                    entry.insert(change.value);
+                    entry.insert(change.had_value);
                 }
                 std::collections::btree_map::Entry::Occupied(_) => {
                     // already touched

--- a/src/tracing/types.rs
+++ b/src/tracing/types.rs
@@ -13,7 +13,7 @@ use alloy_rpc_trace_types::{
 };
 use revm::interpreter::{opcode, CallContext, CallScheme, CreateScheme, InstructionResult, OpCode};
 use serde::{Deserialize, Serialize};
-use std::collections::{VecDeque};
+use std::collections::VecDeque;
 
 /// A trace of a call.
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/src/tracing/types.rs
+++ b/src/tracing/types.rs
@@ -13,7 +13,7 @@ use alloy_rpc_trace_types::{
 };
 use revm::interpreter::{opcode, CallContext, CallScheme, CreateScheme, InstructionResult, OpCode};
 use serde::{Deserialize, Serialize};
-use std::collections::{BTreeMap, VecDeque};
+use std::collections::{VecDeque};
 
 /// A trace of a call.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -145,28 +145,6 @@ impl CallTraceNode {
         } else {
             self.trace.address
         }
-    }
-
-    /// Returns all storage slots touched by this trace and the original value of this storage.
-    ///
-    /// A touched slot is either a slot that was written to or read from.
-    ///
-    /// If the slot is accessed more than once, the result only includes the first time it was
-    /// accessed, in other words it only returns the original value of the slot.
-    pub fn touched_slots_original_values(&self) -> BTreeMap<U256, Option<U256>> {
-        let mut touched_slots = BTreeMap::new();
-        for change in self.trace.steps.iter().filter_map(|s| s.storage_change.as_ref()) {
-            match touched_slots.entry(change.key) {
-                std::collections::btree_map::Entry::Vacant(entry) => {
-                    entry.insert(change.had_value);
-                }
-                std::collections::btree_map::Entry::Occupied(_) => {
-                    // already touched
-                }
-            }
-        }
-
-        touched_slots
     }
 
     /// Pushes all steps onto the stack in reverse order


### PR DESCRIPTION
Closes #13

~~This could potentially be simplified if we can simply use the result's statediff if this has the initial value for modified slots and not just the previous~~

because the prestate tracer should only include changed slots:

https://github.com/ethereum/go-ethereum/blob/bc0b87ca196f92e5af49bd33cc190ef0ec32b197/eth/tracers/native/prestate.go#L216-L224

simplifies prestate result by only checking changed accounts and using the original value

cc @rakita 