### PR TITLE
fix: prestate tracer

### DIFF
--- a/src/tracing/builder/geth.rs
+++ b/src/tracing/builder/geth.rs
@@ -194,6 +194,10 @@ impl GethTraceBuilder {
                 let mut acc_state =
                     AccountState::from_account_info(db_acc.nonce, db_acc.balance, code);
 
+                for (key, slot) in changed_acc.storage.iter() {
+                    println!("{:?} key: {:?}, slot: {:?}", addr, key, slot);
+                }
+
                 // insert the original value of all modified storage slots
                 for (key, slot) in changed_acc.storage.iter().filter(|(_, slot)| slot.is_changed())
                 {

--- a/src/tracing/builder/geth.rs
+++ b/src/tracing/builder/geth.rs
@@ -194,17 +194,8 @@ impl GethTraceBuilder {
                 let mut acc_state =
                     AccountState::from_account_info(db_acc.nonce, db_acc.balance, code);
 
-                for (key, slot) in changed_acc.storage.iter() {
-                    println!("{:?} key: {:?}, slot: {:?}", addr, key, slot);
-                }
-
                 // insert the original value of all modified storage slots
-                for (key, slot) in changed_acc.storage.iter().filter(|(_, slot)| slot.is_changed())
-                {
-                    // empty slots are excluded
-                    if slot.previous_or_original_value.is_zero() {
-                        continue;
-                    }
+                for (key, slot) in changed_acc.storage.iter() {
                     acc_state.storage.insert((*key).into(), slot.previous_or_original_value.into());
                 }
 


### PR DESCRIPTION
prestate tracer should include all slots and don't do any cleanup because cleanup skipped if not diffmode:

https://github.com/ethereum/go-ethereum/blob/fc380f52ef9778e988266f776b9593ce719cf79d/eth/tracers/native/prestate.go#L187-L189

ref 
https://github.com/paradigmxyz/reth/issues/6429