### PR TITLE
chore(clippy): make clippy happy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ rust.missing_debug_implementations = "warn"
 rust.missing_docs = "warn"
 rust.unreachable_pub = "warn"
 rustdoc.all = "warn"
-rust.unused_must_use = "deny"
 rust.rust_2018_idioms = "deny"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,9 @@ rust.missing_debug_implementations = "warn"
 rust.missing_docs = "warn"
 rust.unreachable_pub = "warn"
 rustdoc.all = "warn"
+rust.unused_must_use = "deny"
 rust.rust_2018_idioms = "deny"
+clippy.lint_groups_priority = "allow"
 
 [dependencies]
 # eth


### PR DESCRIPTION
rm redundant lint https://github.com/paradigmxyz/evm-inspectors/actions/runs/7855531397/job/21437338557#step:5:19

```
error: lint group `rust_2018_idioms` has the same priority (0) as a lint
  --> Cargo.toml:19:6
   |
18 | rust.unused_must_use = "deny"
   |      --------------- has the same priority as this lint
19 | rust.rust_2018_idioms = "deny"
   |      ^^^^^^^^^^^^^^^^   ------ has an implicit priority of 0
```