### PR TITLE
feat: bump alloy rpc types rev

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,8 @@ clippy.lint_groups_priority = "allow"
 # eth
 alloy-sol-types = "0.6"
 alloy-primitives = "0.6"
-alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", rev = "5062eaf" }
-alloy-rpc-trace-types = { git = "https://github.com/alloy-rs/alloy", rev = "5062eaf" }
+alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", rev = "76c70fb" }
+alloy-rpc-trace-types = { git = "https://github.com/alloy-rs/alloy", rev = "76c70fb" }
 revm = { version = "6.0", default-features = false, features = ["std"] }
 
 anstyle = "1.0"


### PR DESCRIPTION
## Overview

Updates `alloy-rpc-types` and `alloy-rpc-trace-types` to `76c70fb9d44ace661bbf33408c2527e3874c964e`, which contains https://github.com/alloy-rs/alloy/pull/227