### PR TITLE
feat: bump alloy rpc types rev

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,8 @@ clippy.lint_groups_priority = "allow"
 # eth
 alloy-sol-types = "0.6"
 alloy-primitives = "0.6"
-alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", rev = "52bf712" }
-alloy-rpc-trace-types = { git = "https://github.com/alloy-rs/alloy", rev = "52bf712" }
+alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", rev = "785c667" }
+alloy-rpc-trace-types = { git = "https://github.com/alloy-rs/alloy", rev = "785c667" }
 revm = { version = "6.0", default-features = false, features = ["std"] }
 
 anstyle = "1.0"


### PR DESCRIPTION
Updates `alloy-rpc-types` and `alloy-rpc-trace-types` to `785c667813a6c76794044b943df58fc6e397734d`, which contains https://github.com/alloy-rs/alloy/pull/245