### PR TITLE
chore: remove unused code var

### DIFF
--- a/src/tracing/mod.rs
+++ b/src/tracing/mod.rs
@@ -534,20 +534,6 @@ where
     ) -> CreateOutcome {
         let outcome = self.gas_inspector.create_end(context, inputs, outcome);
 
-        // get the code of the created contract
-        let _code = outcome
-            .address
-            .and_then(|address| {
-                context
-                    .journaled_state
-                    .account(address)
-                    .info
-                    .code
-                    .as_ref()
-                    .map(|code| code.bytes()[..code.len()].to_vec())
-            })
-            .unwrap_or_default();
-
         self.fill_trace_on_call_end(context, outcome.result.clone(), outcome.address);
 
         outcome


### PR DESCRIPTION
this is a leftover of #11 

@rakita 

the `output` of `CreateOutcome` is the runtime bytecode, right?


https://github.com/paradigmxyz/evm-inspectors/blob/05352cd16db13fd89e9a974487b456e3f1498c69/src/tracing/types.rs#L48-L50