### PR TITLE
feat(tracing): implement muxTracer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,8 @@ clippy.lint_groups_priority = "allow"
 # eth
 alloy-sol-types = "0.6"
 alloy-primitives = "0.6"
-alloy-rpc-types = { git = "https://github.com/ArtificialPB/alloy", rev = "fc00e4e" }
-alloy-rpc-trace-types = { git = "https://github.com/ArtificialPB/alloy", rev = "fc00e4e" }
+alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", rev = "fc00e4e" }
+alloy-rpc-trace-types = { git = "https://github.com/alloy-rs/alloy", rev = "fc00e4e" }
 revm = { version = "6.0", default-features = false, features = ["std"] }
 
 anstyle = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,25 +23,25 @@ clippy.lint_groups_priority = "allow"
 # eth
 alloy-sol-types = "0.6"
 alloy-primitives = "0.6"
-alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", rev = "975a52a" }
-alloy-rpc-trace-types = { git = "https://github.com/alloy-rs/alloy", rev = "975a52a" }
+alloy-rpc-types = { git = "https://github.com/ArtificialPB/alloy", rev = "fc00e4e" }
+alloy-rpc-trace-types = { git = "https://github.com/ArtificialPB/alloy", rev = "fc00e4e" }
 revm = { version = "6.0", default-features = false, features = ["std"] }
 
 anstyle = "1.0"
 colorchoice = "1.0"
+thiserror = { version = "1"}
 
 # serde
 serde = { version = "1", optional = true, features = ["derive"] }
+serde_json = { version = "1" }
 
 # js-tracer
 boa_engine = { version = "0.17", optional = true }
 boa_gc = { version = "0.17", optional = true }
-thiserror = { version = "1", optional = true }
-serde_json = { version = "1", optional = true }
 
 [dev-dependencies]
 expect-test = "1.4"
 
 [features]
 serde = ["dep:serde", "revm/serde"]
-js-tracer = ["dep:boa_engine", "dep:boa_gc", "dep:thiserror", "dep:serde_json"]
+js-tracer = ["dep:boa_engine", "dep:boa_gc"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,8 @@ clippy.lint_groups_priority = "allow"
 # eth
 alloy-sol-types = "0.6"
 alloy-primitives = "0.6"
-alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", rev = "fc00e4e" }
-alloy-rpc-trace-types = { git = "https://github.com/alloy-rs/alloy", rev = "fc00e4e" }
+alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", rev = "64d0352" }
+alloy-rpc-trace-types = { git = "https://github.com/alloy-rs/alloy", rev = "64d0352" }
 revm = { version = "6.0", default-features = false, features = ["std"] }
 
 anstyle = "1.0"

--- a/src/tracing/mod.rs
+++ b/src/tracing/mod.rs
@@ -47,7 +47,7 @@ pub use writer::TraceWriter;
 pub mod js;
 
 mod mux;
-pub use mux::MuxInspector;
+pub use mux::{Error as MuxError, MuxInspector};
 
 /// An inspector that collects call traces.
 ///

--- a/src/tracing/mod.rs
+++ b/src/tracing/mod.rs
@@ -46,6 +46,9 @@ pub use writer::TraceWriter;
 #[cfg(feature = "js-tracer")]
 pub mod js;
 
+mod mux;
+pub use mux::MuxInspector;
+
 /// An inspector that collects call traces.
 ///
 /// This [Inspector] can be hooked into revm's EVM which then calls the inspector

--- a/src/tracing/mux.rs
+++ b/src/tracing/mux.rs
@@ -1,0 +1,395 @@
+use crate::tracing::{FourByteInspector, TracingInspector, TracingInspectorConfig};
+use alloy_primitives::{Address, Log, U256};
+use alloy_rpc_trace_types::geth::{
+    mux::{MuxConfig, MuxFrame},
+    CallConfig, FourByteFrame, GethDebugBuiltInTracerType, GethDebugTracerConfig, GethTrace,
+    NoopFrame, PreStateConfig,
+};
+use revm::{
+    interpreter::{CallInputs, CallOutcome, CreateInputs, CreateOutcome, Interpreter},
+    primitives::ResultAndState,
+    Database, DatabaseRef, EvmContext, Inspector,
+};
+use std::collections::HashMap;
+use thiserror::Error;
+
+/// Mux tracing inspector that runs and collects results of multiple inspectors at once.
+pub struct MuxInspector {
+    /// The list of tracer types with its inspectors.
+    inspectors: Vec<(GethDebugBuiltInTracerType, MultiInspector)>,
+}
+
+impl MuxInspector {
+    /// Try creating a new instance of [MuxInspector] from the given [MuxConfig].
+    pub fn try_new(config: MuxConfig) -> Result<MuxInspector, Error> {
+        let inspectors = config
+            .tracers
+            .into_iter()
+            .map(|(tracer_type, tracer_config)| {
+                MultiInspector::try_new(tracer_type, tracer_config.clone())
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(MuxInspector { inspectors })
+    }
+
+    /// Try converting this [MuxInspector] into a [MuxFrame].
+    pub fn try_into_mux_frame<DB: DatabaseRef>(
+        self,
+        result: &ResultAndState,
+        db: DB,
+    ) -> Result<MuxFrame, DB::Error> {
+        let mut frame = HashMap::with_capacity(self.inspectors.len());
+        for (tracer_type, inspector) in self.inspectors {
+            let trace = match inspector {
+                MultiInspector::FourByteInspector(inspector) => {
+                    FourByteFrame::from(inspector).into()
+                }
+                MultiInspector::CallInspector(config, inspector) => inspector
+                    .into_geth_builder()
+                    .geth_call_traces(config, result.result.gas_used())
+                    .into(),
+                MultiInspector::PrestateInspector(config, inspector) => {
+                    inspector.into_geth_builder().geth_prestate_traces(result, config, &db)?.into()
+                }
+                MultiInspector::NoopInspector => NoopFrame::default().into(),
+                MultiInspector::MuxInspector(inspector) => {
+                    inspector.into_mux_frame(result, &db).map(GethTrace::MuxTracer)?
+                }
+            };
+
+            frame.insert(tracer_type, trace);
+        }
+
+        Ok(MuxFrame(frame))
+    }
+}
+
+impl<DB> Inspector<DB> for MuxInspector
+where
+    DB: Database,
+{
+    #[inline]
+    fn initialize_interp(&mut self, interp: &mut Interpreter, context: &mut EvmContext<DB>) {
+        for (_, inspector) in &mut self.inspectors {
+            inspector.initialize_interp(interp, context);
+        }
+    }
+
+    #[inline]
+    fn step(&mut self, interp: &mut Interpreter, context: &mut EvmContext<DB>) {
+        for (_, inspector) in &mut self.inspectors {
+            inspector.step(interp, context);
+        }
+    }
+
+    #[inline]
+    fn step_end(&mut self, interp: &mut Interpreter, context: &mut EvmContext<DB>) {
+        for (_, inspector) in &mut self.inspectors {
+            inspector.step_end(interp, context);
+        }
+    }
+
+    #[inline]
+    fn log(&mut self, context: &mut EvmContext<DB>, log: &Log) {
+        for (_, inspector) in &mut self.inspectors {
+            inspector.log(context, log);
+        }
+    }
+
+    #[inline]
+    fn call(
+        &mut self,
+        context: &mut EvmContext<DB>,
+        inputs: &mut CallInputs,
+    ) -> Option<CallOutcome> {
+        for (_, inspector) in &mut self.inspectors {
+            if let Some(outcome) = inspector.call(context, inputs) {
+                return Some(outcome);
+            }
+        }
+
+        None
+    }
+
+    #[inline]
+    fn call_end(
+        &mut self,
+        context: &mut EvmContext<DB>,
+        inputs: &CallInputs,
+        outcome: CallOutcome,
+    ) -> CallOutcome {
+        let mut outcome = outcome;
+        for (_, inspector) in &mut self.inspectors {
+            outcome = inspector.call_end(context, inputs, outcome);
+        }
+
+        outcome
+    }
+
+    #[inline]
+    fn create(
+        &mut self,
+        context: &mut EvmContext<DB>,
+        inputs: &mut CreateInputs,
+    ) -> Option<CreateOutcome> {
+        for (_, inspector) in &mut self.inspectors {
+            if let Some(outcome) = inspector.create(context, inputs) {
+                return Some(outcome);
+            }
+        }
+
+        None
+    }
+
+    #[inline]
+    fn create_end(
+        &mut self,
+        context: &mut EvmContext<DB>,
+        inputs: &CreateInputs,
+        outcome: CreateOutcome,
+    ) -> CreateOutcome {
+        let mut outcome = outcome;
+        for (_, inspector) in &mut self.inspectors {
+            outcome = inspector.create_end(context, inputs, outcome);
+        }
+
+        outcome
+    }
+
+    #[inline]
+    fn selfdestruct(&mut self, contract: Address, target: Address, value: U256) {
+        for (_, inspector) in &mut self.inspectors {
+            inspector.selfdestruct::<DB>(contract, target, value);
+        }
+    }
+}
+
+/// An inspector that can delegate to multiple inspector types.
+enum MultiInspector {
+    FourByteInspector(FourByteInspector),
+    CallInspector(CallConfig, TracingInspector),
+    PrestateInspector(PreStateConfig, TracingInspector),
+    NoopInspector,
+    MuxInspector(MuxInspector),
+}
+
+impl MultiInspector {
+    /// Try creating a new instance of [MultiInspector] from the given tracer type and config.
+    pub fn try_new(
+        tracer_type: GethDebugBuiltInTracerType,
+        tracer_config: Option<GethDebugTracerConfig>,
+    ) -> Result<(GethDebugBuiltInTracerType, MultiInspector), Error> {
+        let inspector = match tracer_type {
+            GethDebugBuiltInTracerType::FourByteTracer => {
+                Ok(MultiInspector::FourByteInspector(FourByteInspector::default()))
+            }
+            GethDebugBuiltInTracerType::CallTracer => {
+                let call_config = tracer_config
+                    .ok_or_else(|| Error::MissingConfig(tracer_type))?
+                    .into_call_config()?;
+
+                let inspector = TracingInspector::new(
+                    TracingInspectorConfig::default_geth()
+                        .set_record_logs(call_config.with_log.unwrap_or_default()),
+                );
+
+                Ok(MultiInspector::CallInspector(call_config, inspector))
+            }
+            GethDebugBuiltInTracerType::PreStateTracer => {
+                let prestate_config = tracer_config
+                    .ok_or_else(|| Error::MissingConfig(tracer_type))?
+                    .into_pre_state_config()?;
+
+                let inspector = TracingInspector::new(
+                    TracingInspectorConfig::default_geth()
+                        // if in default mode, we need to return all touched storages, for
+                        // which we need to record steps and statediff
+                        .set_steps_and_state_diffs(prestate_config.is_default_mode()),
+                );
+
+                Ok(MultiInspector::PrestateInspector(prestate_config, inspector))
+            }
+            GethDebugBuiltInTracerType::NoopTracer => Ok(MultiInspector::NoopInspector),
+            GethDebugBuiltInTracerType::MuxTracer => {
+                let config = tracer_config
+                    .ok_or_else(|| Error::MissingConfig(tracer_type))?
+                    .into_mux_config()?;
+
+                Ok(MultiInspector::MuxInspector(MuxInspector::try_new(config)?))
+            }
+        };
+
+        inspector.map(|inspector| (tracer_type, inspector))
+    }
+
+    #[inline]
+    fn initialize_interp<DB: Database>(
+        &mut self,
+        interp: &mut Interpreter,
+        context: &mut EvmContext<DB>,
+    ) {
+        match self {
+            MultiInspector::FourByteInspector(inspector) => {
+                inspector.initialize_interp(interp, context)
+            }
+            MultiInspector::CallInspector(_, inspector) => {
+                inspector.initialize_interp(interp, context)
+            }
+            MultiInspector::PrestateInspector(_, inspector) => {
+                inspector.initialize_interp(interp, context)
+            }
+            MultiInspector::NoopInspector => {}
+            MultiInspector::MuxInspector(inspector) => inspector.initialize_interp(interp, context),
+        }
+    }
+
+    #[inline]
+    fn step<DB: Database>(&mut self, interp: &mut Interpreter, context: &mut EvmContext<DB>) {
+        match self {
+            MultiInspector::FourByteInspector(inspector) => inspector.step(interp, context),
+            MultiInspector::CallInspector(_, inspector) => inspector.step(interp, context),
+            MultiInspector::PrestateInspector(_, inspector) => inspector.step(interp, context),
+            MultiInspector::NoopInspector => {}
+            MultiInspector::MuxInspector(inspector) => inspector.step(interp, context),
+        }
+    }
+
+    #[inline]
+    fn step_end<DB: Database>(&mut self, interp: &mut Interpreter, context: &mut EvmContext<DB>) {
+        match self {
+            MultiInspector::FourByteInspector(inspector) => inspector.step_end(interp, context),
+            MultiInspector::CallInspector(_, inspector) => inspector.step_end(interp, context),
+            MultiInspector::PrestateInspector(_, inspector) => inspector.step_end(interp, context),
+            MultiInspector::NoopInspector => {}
+            MultiInspector::MuxInspector(inspector) => inspector.step_end(interp, context),
+        }
+    }
+
+    #[inline]
+    fn log<DB: Database>(&mut self, context: &mut EvmContext<DB>, log: &Log) {
+        match self {
+            MultiInspector::FourByteInspector(inspector) => inspector.log(context, log),
+            MultiInspector::CallInspector(_, inspector) => inspector.log(context, log),
+            MultiInspector::PrestateInspector(_, inspector) => inspector.log(context, log),
+            MultiInspector::NoopInspector => {}
+            MultiInspector::MuxInspector(inspector) => inspector.log(context, log),
+        }
+    }
+
+    #[inline]
+    fn call<DB: Database>(
+        &mut self,
+        context: &mut EvmContext<DB>,
+        inputs: &mut CallInputs,
+    ) -> Option<CallOutcome> {
+        match self {
+            MultiInspector::FourByteInspector(inspector) => inspector.call(context, inputs),
+            MultiInspector::CallInspector(_, inspector) => inspector.call(context, inputs),
+            MultiInspector::PrestateInspector(_, inspector) => inspector.call(context, inputs),
+            MultiInspector::NoopInspector => None,
+            MultiInspector::MuxInspector(inspector) => inspector.call(context, inputs),
+        };
+
+        None
+    }
+
+    #[inline]
+    fn call_end<DB: Database>(
+        &mut self,
+        context: &mut EvmContext<DB>,
+        inputs: &CallInputs,
+        outcome: CallOutcome,
+    ) -> CallOutcome {
+        match self {
+            MultiInspector::FourByteInspector(inspector) => {
+                inspector.call_end(context, inputs, outcome)
+            }
+            MultiInspector::CallInspector(_, inspector) => {
+                inspector.call_end(context, inputs, outcome)
+            }
+            MultiInspector::PrestateInspector(_, inspector) => {
+                inspector.call_end(context, inputs, outcome)
+            }
+            MultiInspector::NoopInspector => outcome,
+            MultiInspector::MuxInspector(inspector) => inspector.call_end(context, inputs, outcome),
+        }
+    }
+
+    #[inline]
+    fn create<DB: Database>(
+        &mut self,
+        context: &mut EvmContext<DB>,
+        inputs: &mut CreateInputs,
+    ) -> Option<CreateOutcome> {
+        match self {
+            MultiInspector::FourByteInspector(inspector) => inspector.create(context, inputs),
+            MultiInspector::CallInspector(_, inspector) => inspector.create(context, inputs),
+            MultiInspector::PrestateInspector(_, inspector) => inspector.create(context, inputs),
+            MultiInspector::NoopInspector => None,
+            MultiInspector::MuxInspector(inspector) => inspector.create(context, inputs),
+        };
+
+        None
+    }
+
+    #[inline]
+    fn create_end<DB: Database>(
+        &mut self,
+        context: &mut EvmContext<DB>,
+        inputs: &CreateInputs,
+        outcome: CreateOutcome,
+    ) -> CreateOutcome {
+        match self {
+            MultiInspector::FourByteInspector(inspector) => {
+                inspector.create_end(context, inputs, outcome)
+            }
+            MultiInspector::CallInspector(_, inspector) => {
+                inspector.create_end(context, inputs, outcome)
+            }
+            MultiInspector::PrestateInspector(_, inspector) => {
+                inspector.create_end(context, inputs, outcome)
+            }
+            MultiInspector::NoopInspector => outcome,
+            MultiInspector::MuxInspector(inspector) => {
+                inspector.create_end(context, inputs, outcome)
+            }
+        }
+    }
+
+    #[inline]
+    fn selfdestruct<DB: Database>(&mut self, contract: Address, target: Address, value: U256) {
+        match self {
+            MultiInspector::FourByteInspector(inspector) => {
+                <FourByteInspector as Inspector<DB>>::selfdestruct(
+                    inspector, contract, target, value,
+                )
+            }
+            MultiInspector::CallInspector(_, inspector) => {
+                <TracingInspector as Inspector<DB>>::selfdestruct(
+                    inspector, contract, target, value,
+                )
+            }
+            MultiInspector::PrestateInspector(_, inspector) => {
+                <TracingInspector as Inspector<DB>>::selfdestruct(
+                    inspector, contract, target, value,
+                )
+            }
+            MultiInspector::NoopInspector => {}
+            MultiInspector::MuxInspector(inspector) => {
+                <MuxInspector as Inspector<DB>>::selfdestruct(inspector, contract, target, value)
+            }
+        }
+    }
+}
+
+/// Error type for [MuxInspector]
+#[derive(Debug, Error)]
+pub enum Error {
+    /// Expected config is missing
+    #[error("expected config is missing for tracer '{0:?}'")]
+    MissingConfig(GethDebugBuiltInTracerType),
+    /// Error when deserializing the config
+    #[error("error deserializing config: {0}")]
+    InvalidConfig(#[from] serde_json::Error),
+}

--- a/src/tracing/mux.rs
+++ b/src/tracing/mux.rs
@@ -37,7 +37,7 @@ impl MuxInspector {
     pub fn try_into_mux_frame<DB: DatabaseRef>(
         self,
         result: &ResultAndState,
-        db: DB,
+        db: &DB,
     ) -> Result<MuxFrame, DB::Error> {
         let mut frame = HashMap::with_capacity(self.inspectors.len());
         for (tracer_type, inspector) in self.inspectors {
@@ -50,11 +50,11 @@ impl MuxInspector {
                     .geth_call_traces(config, result.result.gas_used())
                     .into(),
                 MultiInspector::PrestateInspector(config, inspector) => {
-                    inspector.into_geth_builder().geth_prestate_traces(result, config, &db)?.into()
+                    inspector.into_geth_builder().geth_prestate_traces(result, config, db)?.into()
                 }
                 MultiInspector::NoopInspector => NoopFrame::default().into(),
                 MultiInspector::MuxInspector(inspector) => {
-                    inspector.into_mux_frame(result, &db).map(GethTrace::MuxTracer)?
+                    inspector.try_into_mux_frame(result, db).map(GethTrace::MuxTracer)?
                 }
             };
 

--- a/src/tracing/mux.rs
+++ b/src/tracing/mux.rs
@@ -103,7 +103,9 @@ where
         inputs: &mut CallInputs,
     ) -> Option<CallOutcome> {
         for (_, inspector) in &mut self.inspectors {
-            let _ = inspector.call(context, inputs);
+            if let Some(outcome) = inspector.call(context, inputs) {
+                return Some(outcome);
+            }
         }
 
         None
@@ -131,7 +133,9 @@ where
         inputs: &mut CreateInputs,
     ) -> Option<CreateOutcome> {
         for (_, inspector) in &mut self.inspectors {
-            let _ = inspector.create(context, inputs);
+            if let Some(outcome) = inspector.create(context, inputs) {
+                return Some(outcome);
+            }
         }
 
         None

--- a/src/tracing/mux.rs
+++ b/src/tracing/mux.rs
@@ -22,12 +22,12 @@ pub struct MuxInspector {
 
 impl MuxInspector {
     /// Try creating a new instance of [MuxInspector] from the given [MuxConfig].
-    pub fn try_new(config: MuxConfig) -> Result<MuxInspector, Error> {
+    pub fn try_from_config(config: MuxConfig) -> Result<MuxInspector, Error> {
         let inspectors = config
             .tracers
             .into_iter()
             .map(|(tracer_type, tracer_config)| {
-                MultiInspector::try_new(tracer_type, tracer_config.clone())
+                MultiInspector::try_from_config(tracer_type, tracer_config.clone())
             })
             .collect::<Result<Vec<_>, _>>()?;
 
@@ -178,7 +178,7 @@ enum MultiInspector {
 
 impl MultiInspector {
     /// Try creating a new instance of [MultiInspector] from the given tracer type and config.
-    pub(crate) fn try_new(
+    pub(crate) fn try_from_config(
         tracer_type: GethDebugBuiltInTracerType,
         tracer_config: Option<GethDebugTracerConfig>,
     ) -> Result<(GethDebugBuiltInTracerType, MultiInspector), Error> {
@@ -226,7 +226,7 @@ impl MultiInspector {
                     .ok_or_else(|| Error::MissingConfig(tracer_type))?
                     .into_mux_config()?;
 
-                Ok(MultiInspector::MuxInspector(MuxInspector::try_new(config)?))
+                Ok(MultiInspector::MuxInspector(MuxInspector::try_from_config(config)?))
             }
         };
 

--- a/tests/it/geth.rs
+++ b/tests/it/geth.rs
@@ -210,7 +210,7 @@ fn test_geth_mux_tracer() {
         ]),
     };
 
-    let mut insp = MuxInspector::try_new(config.clone()).unwrap();
+    let mut insp = MuxInspector::try_from_config(config.clone()).unwrap();
 
     // Create contract
     let (res, _) = inspect(&mut db, env, &mut insp).unwrap();
@@ -223,7 +223,7 @@ fn test_geth_mux_tracer() {
     };
     db.commit(res.state);
 
-    let mut insp = MuxInspector::try_new(config.clone()).unwrap();
+    let mut insp = MuxInspector::try_from_config(config.clone()).unwrap();
 
     let env = EnvWithHandlerCfg::new_with_cfg_env(
         cfg,

--- a/tests/it/geth.rs
+++ b/tests/it/geth.rs
@@ -185,30 +185,26 @@ fn test_geth_mux_tracer() {
     let prestate_config = PreStateConfig { diff_mode: Some(false) };
 
     let nested_call_config = CallConfig { only_top_call: Some(true), with_log: Some(false) };
-    let nested_mux_config = MuxConfig {
-        tracers: HashMap::from([(
-            GethDebugBuiltInTracerType::CallTracer,
-            Some(GethDebugTracerConfig(serde_json::to_value(nested_call_config).unwrap())),
-        )]),
-    };
+    let nested_mux_config = MuxConfig(HashMap::from([(
+        GethDebugBuiltInTracerType::CallTracer,
+        Some(GethDebugTracerConfig(serde_json::to_value(nested_call_config).unwrap())),
+    )]));
 
-    let config = MuxConfig {
-        tracers: HashMap::from([
-            (GethDebugBuiltInTracerType::FourByteTracer, None),
-            (
-                GethDebugBuiltInTracerType::CallTracer,
-                Some(GethDebugTracerConfig(serde_json::to_value(call_config).unwrap())),
-            ),
-            (
-                GethDebugBuiltInTracerType::PreStateTracer,
-                Some(GethDebugTracerConfig(serde_json::to_value(prestate_config).unwrap())),
-            ),
-            (
-                GethDebugBuiltInTracerType::MuxTracer,
-                Some(GethDebugTracerConfig(serde_json::to_value(nested_mux_config).unwrap())),
-            ),
-        ]),
-    };
+    let config = MuxConfig(HashMap::from([
+        (GethDebugBuiltInTracerType::FourByteTracer, None),
+        (
+            GethDebugBuiltInTracerType::CallTracer,
+            Some(GethDebugTracerConfig(serde_json::to_value(call_config).unwrap())),
+        ),
+        (
+            GethDebugBuiltInTracerType::PreStateTracer,
+            Some(GethDebugTracerConfig(serde_json::to_value(prestate_config).unwrap())),
+        ),
+        (
+            GethDebugBuiltInTracerType::MuxTracer,
+            Some(GethDebugTracerConfig(serde_json::to_value(nested_mux_config).unwrap())),
+        ),
+    ]));
 
     let mut insp = MuxInspector::try_from_config(config.clone()).unwrap();
 

--- a/tests/it/geth.rs
+++ b/tests/it/geth.rs
@@ -2,7 +2,10 @@
 
 use crate::utils::inspect;
 use alloy_primitives::{hex, Address, Bytes};
-use alloy_rpc_trace_types::geth::CallConfig;
+use alloy_rpc_trace_types::geth::{
+    mux::MuxConfig, CallConfig, GethDebugBuiltInTracerType, GethDebugTracerConfig, GethTrace,
+    PreStateConfig,
+};
 use revm::{
     db::{CacheDB, EmptyDB},
     interpreter::CreateScheme,
@@ -12,7 +15,8 @@ use revm::{
     },
     DatabaseCommit,
 };
-use revm_inspectors::tracing::{TracingInspector, TracingInspectorConfig};
+use revm_inspectors::tracing::{MuxInspector, TracingInspector, TracingInspectorConfig};
+use std::collections::HashMap;
 
 #[test]
 fn test_geth_calltracer_logs() {
@@ -70,6 +74,7 @@ fn test_geth_calltracer_logs() {
 
     let mut insp = TracingInspector::new(TracingInspectorConfig::default_geth());
 
+    // Create contract
     let (res, _) = inspect(&mut db, env, &mut insp).unwrap();
     let addr = match res.result {
         ExecutionResult::Success { output, .. } => match output {
@@ -120,4 +125,165 @@ fn test_geth_calltracer_logs() {
 
     // third call succeeded, one log
     assert_eq!(call_frame.calls[2].logs.len(), 1);
+}
+
+#[test]
+fn test_geth_mux_tracer() {
+    /*
+    contract LogTracing {
+        event Log(address indexed addr, uint256 value);
+
+        fallback() external payable {
+            emit Log(msg.sender, msg.value);
+
+            try this.nestedEmitWithFailure() {} catch {}
+            try this.nestedEmitWithFailureAfterNestedEmit() {} catch {}
+            this.nestedEmitWithSuccess();
+        }
+
+        function nestedEmitWithFailure() external {
+            emit Log(msg.sender, 0);
+            require(false, "nestedEmitWithFailure");
+        }
+
+        function nestedEmitWithFailureAfterNestedEmit() external {
+            this.doubleNestedEmitWithSuccess();
+            require(false, "nestedEmitWithFailureAfterNestedEmit");
+        }
+
+        function doubleNestedEmitWithSuccess() external {
+            emit Log(msg.sender, 0);
+            this.nestedEmitWithSuccess();
+        }
+
+        function nestedEmitWithSuccess() external {
+            emit Log(msg.sender, 0);
+        }
+    }
+    */
+
+    let code = hex!("608060405234801561001057600080fd5b506103ac806100206000396000f3fe60806040526004361061003f5760003560e01c80630332ed131461014d5780636ae1ad40146101625780638384a00214610177578063de7eb4f31461018c575b60405134815233906000805160206103578339815191529060200160405180910390a2306001600160a01b0316636ae1ad406040518163ffffffff1660e01b8152600401600060405180830381600087803b15801561009d57600080fd5b505af19250505080156100ae575060015b50306001600160a01b0316630332ed136040518163ffffffff1660e01b8152600401600060405180830381600087803b1580156100ea57600080fd5b505af19250505080156100fb575060015b50306001600160a01b0316638384a0026040518163ffffffff1660e01b8152600401600060405180830381600087803b15801561013757600080fd5b505af115801561014b573d6000803e3d6000fd5b005b34801561015957600080fd5b5061014b6101a1565b34801561016e57600080fd5b5061014b610253565b34801561018357600080fd5b5061014b6102b7565b34801561019857600080fd5b5061014b6102dd565b306001600160a01b031663de7eb4f36040518163ffffffff1660e01b8152600401600060405180830381600087803b1580156101dc57600080fd5b505af11580156101f0573d6000803e3d6000fd5b505060405162461bcd60e51b8152602060048201526024808201527f6e6573746564456d6974576974684661696c75726541667465724e6573746564604482015263115b5a5d60e21b6064820152608401915061024a9050565b60405180910390fd5b6040516000815233906000805160206103578339815191529060200160405180910390a260405162461bcd60e51b81526020600482015260156024820152746e6573746564456d6974576974684661696c75726560581b604482015260640161024a565b6040516000815233906000805160206103578339815191529060200160405180910390a2565b6040516000815233906000805160206103578339815191529060200160405180910390a2306001600160a01b0316638384a0026040518163ffffffff1660e01b8152600401600060405180830381600087803b15801561033c57600080fd5b505af1158015610350573d6000803e3d6000fd5b5050505056fef950957d2407bed19dc99b718b46b4ce6090c05589006dfb86fd22c34865b23ea2646970667358221220090a696b9fbd22c7d1cc2a0b6d4a48c32d3ba892480713689a3145b73cfeb02164736f6c63430008130033");
+    let deployer = Address::ZERO;
+
+    let mut db = CacheDB::new(EmptyDB::default());
+
+    let cfg = CfgEnvWithHandlerCfg::new(CfgEnv::default(), HandlerCfg::new(SpecId::LONDON));
+
+    let env = EnvWithHandlerCfg::new_with_cfg_env(
+        cfg.clone(),
+        BlockEnv::default(),
+        TxEnv {
+            caller: deployer,
+            gas_limit: 1000000,
+            transact_to: TransactTo::Create(CreateScheme::Create),
+            data: code.into(),
+            ..Default::default()
+        },
+    );
+
+    let call_config = CallConfig { only_top_call: Some(false), with_log: Some(true) };
+    let prestate_config = PreStateConfig { diff_mode: Some(false) };
+
+    let nested_call_config = CallConfig { only_top_call: Some(true), with_log: Some(false) };
+    let nested_mux_config = MuxConfig {
+        tracers: HashMap::from([(
+            GethDebugBuiltInTracerType::CallTracer,
+            Some(GethDebugTracerConfig(serde_json::to_value(nested_call_config).unwrap())),
+        )]),
+    };
+
+    let config = MuxConfig {
+        tracers: HashMap::from([
+            (GethDebugBuiltInTracerType::FourByteTracer, None),
+            (
+                GethDebugBuiltInTracerType::CallTracer,
+                Some(GethDebugTracerConfig(serde_json::to_value(call_config).unwrap())),
+            ),
+            (
+                GethDebugBuiltInTracerType::PreStateTracer,
+                Some(GethDebugTracerConfig(serde_json::to_value(prestate_config).unwrap())),
+            ),
+            (
+                GethDebugBuiltInTracerType::MuxTracer,
+                Some(GethDebugTracerConfig(serde_json::to_value(nested_mux_config).unwrap())),
+            ),
+        ]),
+    };
+
+    let mut insp = MuxInspector::try_new(config.clone()).unwrap();
+
+    // Create contract
+    let (res, _) = inspect(&mut db, env, &mut insp).unwrap();
+    let addr = match res.result {
+        ExecutionResult::Success { output, .. } => match output {
+            Output::Create(_, addr) => addr.unwrap(),
+            _ => panic!("Create failed"),
+        },
+        _ => panic!("Execution failed"),
+    };
+    db.commit(res.state);
+
+    let mut insp = MuxInspector::try_new(config.clone()).unwrap();
+
+    let env = EnvWithHandlerCfg::new_with_cfg_env(
+        cfg,
+        BlockEnv::default(),
+        TxEnv {
+            caller: deployer,
+            gas_limit: 1000000,
+            transact_to: TransactTo::Call(addr),
+            data: Bytes::default(), // call fallback
+            ..Default::default()
+        },
+    );
+
+    let (res, _) = inspect(&mut db, env, &mut insp).unwrap();
+    assert!(res.result.is_success());
+
+    let frame = insp.try_into_mux_frame(&res, &db).unwrap();
+
+    assert_eq!(frame.0.len(), 4);
+    assert!(frame.0.contains_key(&GethDebugBuiltInTracerType::FourByteTracer));
+    assert!(frame.0.contains_key(&GethDebugBuiltInTracerType::CallTracer));
+    assert!(frame.0.contains_key(&GethDebugBuiltInTracerType::PreStateTracer));
+    assert!(frame.0.contains_key(&GethDebugBuiltInTracerType::MuxTracer));
+
+    let four_byte_frame = frame.0[&GethDebugBuiltInTracerType::FourByteTracer].clone();
+    match four_byte_frame {
+        GethTrace::FourByteTracer(four_byte_frame) => {
+            assert_eq!(four_byte_frame.0.len(), 4);
+            assert!(four_byte_frame.0.contains_key("0x0332ed13-0"));
+            assert!(four_byte_frame.0.contains_key("0x6ae1ad40-0"));
+            assert!(four_byte_frame.0.contains_key("0x8384a002-0"));
+            assert!(four_byte_frame.0.contains_key("0xde7eb4f3-0"));
+        }
+        _ => panic!("Expected FourByteTracer"),
+    }
+
+    let call_frame = frame.0[&GethDebugBuiltInTracerType::CallTracer].clone();
+    match call_frame {
+        GethTrace::CallTracer(call_frame) => {
+            assert_eq!(call_frame.calls.len(), 3);
+            assert_eq!(call_frame.logs.len(), 1);
+        }
+        _ => panic!("Expected CallTracer"),
+    }
+
+    let nested_frame = frame.0[&GethDebugBuiltInTracerType::MuxTracer].clone();
+    match nested_frame {
+        GethTrace::MuxTracer(nested_frame) => {
+            assert_eq!(nested_frame.0.len(), 1);
+            assert!(nested_frame.0.contains_key(&GethDebugBuiltInTracerType::CallTracer));
+
+            let nested_call_frame = nested_frame.0[&GethDebugBuiltInTracerType::CallTracer].clone();
+            match nested_call_frame {
+                GethTrace::CallTracer(nested_call_frame) => {
+                    assert_eq!(nested_call_frame.calls.len(), 0);
+                    assert_eq!(nested_call_frame.logs.len(), 0);
+                }
+                _ => panic!("Expected CallTracer"),
+            }
+        }
+        _ => panic!("Expected MuxTracer"),
+    }
 }


### PR DESCRIPTION
Adds support for `muxTracer`. Depends on changes from https://github.com/alloy-rs/alloy/pull/252

Once both PR's are good to go I'll open a PR also for `reth`.