### PR TITLE
feat: more geth tracer config functions

### DIFF
--- a/src/tracing/config.rs
+++ b/src/tracing/config.rs
@@ -118,7 +118,7 @@ impl TracingInspectorConfig {
     /// This returns [Self::none] and enables [TracingInspectorConfig::record_logs] if configured in
     /// the given [CallConfig]
     #[inline]
-    pub const fn from_geth_call_config(config: &CallConfig) -> Self {
+    pub fn from_geth_call_config(config: &CallConfig) -> Self {
         Self::none()
             // call tracer is similar parity tracer with optional support for logs
             .set_record_logs(config.with_log.unwrap_or_default())
@@ -148,7 +148,7 @@ impl TracingInspectorConfig {
     }
 
     /// Enable recording of individual opcode level steps
-    pub const fn steps(mut self) -> Self {
+    pub const fn steps(self) -> Self {
         self.set_steps(true)
     }
 
@@ -164,7 +164,7 @@ impl TracingInspectorConfig {
     }
 
     /// Enable recording of individual memory snapshots
-    pub const fn memory_snapshots(mut self) -> Self {
+    pub const fn memory_snapshots(self) -> Self {
         self.set_memory_snapshots(true)
     }
 
@@ -180,7 +180,7 @@ impl TracingInspectorConfig {
     }
 
     /// Enable recording of individual stack snapshots
-    pub const fn stack_snapshots(mut self) -> Self {
+    pub const fn stack_snapshots(self) -> Self {
         self.set_stack_snapshots(StackSnapshotType::Full)
     }
 
@@ -191,7 +191,7 @@ impl TracingInspectorConfig {
     }
 
     /// Disable recording of state diffs
-    pub const fn disable_state_diffs(mut self) -> Self {
+    pub const fn disable_state_diffs(self) -> Self {
         self.set_state_diffs(false)
     }
 
@@ -224,7 +224,7 @@ impl TracingInspectorConfig {
     }
 
     /// Enable recording of individual logs
-    pub const fn record_logs(mut self) -> Self {
+    pub const fn record_logs(self) -> Self {
         self.set_record_logs(true)
     }
 

--- a/src/tracing/mux.rs
+++ b/src/tracing/mux.rs
@@ -192,8 +192,7 @@ impl DelegatingInspector {
                     .into_call_config()?;
 
                 let inspector = TracingInspector::new(
-                    TracingInspectorConfig::default_geth()
-                        .set_record_logs(call_config.with_log.unwrap_or_default()),
+                    TracingInspectorConfig::from_geth_call_config(&call_config),
                 );
 
                 Ok(DelegatingInspector::Call(call_config, inspector))
@@ -204,10 +203,7 @@ impl DelegatingInspector {
                     .into_pre_state_config()?;
 
                 let inspector = TracingInspector::new(
-                    TracingInspectorConfig::default_geth()
-                        // if in default mode, we need to return all touched storages, for
-                        // which we need to record steps and statediff
-                        .set_steps_and_state_diffs(prestate_config.is_default_mode()),
+                    TracingInspectorConfig::from_geth_prestate_config(&prestate_config),
                 );
 
                 Ok(DelegatingInspector::Prestate(prestate_config, inspector))


### PR DESCRIPTION
blocked by https://github.com/bluealloy/revm/pull/1174

the `GethDefaultTracingOptions` dont have any effect on the call and prestate tracer

this adds special functions for those tracers.

The prestate tracer can be simplified entirely and doesn't even have to be a tracer I think, but need to handle that separately