### PR TITLE
bump alloy rpc deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,8 @@ clippy.lint_groups_priority = "allow"
 # eth
 alloy-sol-types = "0.7.0"
 alloy-primitives = "0.7.0"
-alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", rev = "a32e6f7" }
-alloy-rpc-types-trace = { git = "https://github.com/alloy-rs/alloy", rev = "a32e6f7" }
+alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", rev = "44c905d" }
+alloy-rpc-types-trace = { git = "https://github.com/alloy-rs/alloy", rev = "44c905d" }
 revm = { version = "8.0", default-features = false, features = ["std"] }
 
 anstyle = "1.0"


### PR DESCRIPTION
## Motivation

Alloy deps need to be bumped in https://github.com/foundry-rs/foundry/pull/7619. This creates a conflicting deps version between `evm-inspectors` and `foundry` for `alloy-rpc-types` and `alloy-rpc-types-trace`

## Solution

Bump to latest alloy commit