### PR TITLE
chore(deps): bump to alloy-core to `0.7.1` and alloy to `98da8b8`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,10 +21,10 @@ clippy.lint_groups_priority = "allow"
 
 [dependencies]
 # eth
-alloy-sol-types = "0.7.0"
-alloy-primitives = "0.7.0"
-alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", rev = "39b8695" }
-alloy-rpc-types-trace = { git = "https://github.com/alloy-rs/alloy", rev = "39b8695" }
+alloy-sol-types = "0.7.1"
+alloy-primitives = "0.7.1"
+alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", rev = "98da8b8" }
+alloy-rpc-types-trace = { git = "https://github.com/alloy-rs/alloy", rev = "98da8b8" }
 revm = { version = "8.0", default-features = false, features = ["std"] }
 
 anstyle = "1.0"


### PR DESCRIPTION
Updates to https://github.com/alloy-rs/core/releases/tag/v0.7.1

Required for Foundry's update to Alloy