### PR TITLE
chore: bump alloy 17c5650

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,8 @@ clippy.lint_groups_priority = "allow"
 # eth
 alloy-sol-types = "0.7.1"
 alloy-primitives = "0.7.1"
-alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", rev = "0bb7604" }
-alloy-rpc-types-trace = { git = "https://github.com/alloy-rs/alloy", rev = "0bb7604" }
+alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", rev = "17c5650" }
+alloy-rpc-types-trace = { git = "https://github.com/alloy-rs/alloy", rev = "17c5650" }
 revm = { version = "8.0", default-features = false, features = ["std"] }
 
 anstyle = "1.0"


### PR DESCRIPTION
required for https://github.com/foundry-rs/foundry/issues/7867

also includes new fn for https://github.com/paradigmxyz/reth/pull/7993

cc @fgimenez 