### PR TITLE
Fix index out of bound when resetting TracingInspector

### DIFF
--- a/src/tracing/arena.rs
+++ b/src/tracing/arena.rs
@@ -33,7 +33,7 @@ impl CallTraceArena {
     /// Note that this method has no effect on the allocated capacity of the arena.
     #[inline]
     pub fn clear(&mut self) {
-        self.arena.clear();
+        self.arena = vec![Default::default()];
     }
 
     /// Pushes a new trace into the arena, returning the trace ID

--- a/src/tracing/arena.rs
+++ b/src/tracing/arena.rs
@@ -33,7 +33,8 @@ impl CallTraceArena {
     /// Note that this method has no effect on the allocated capacity of the arena.
     #[inline]
     pub fn clear(&mut self) {
-        self.arena = vec![Default::default()];
+        self.arena.clear();
+        self.arena.push(Default::default());
     }
 
     /// Pushes a new trace into the arena, returning the trace ID

--- a/tests/it/geth.rs
+++ b/tests/it/geth.rs
@@ -283,3 +283,38 @@ fn test_geth_mux_tracer() {
         _ => panic!("Expected MuxTracer"),
     }
 }
+
+#[test]
+fn test_geth_inspector_reset() {
+    let mut insp = TracingInspector::new(TracingInspectorConfig::default_geth());
+
+    let mut db = CacheDB::new(EmptyDB::default());
+    let cfg = CfgEnvWithHandlerCfg::new(CfgEnv::default(), HandlerCfg::new(SpecId::LONDON));
+    let env = EnvWithHandlerCfg::new_with_cfg_env(
+        cfg.clone(),
+        BlockEnv::default(),
+        TxEnv {
+            caller: Address::ZERO,
+            gas_limit: 1000000,
+            gas_price: Default::default(),
+            transact_to: TransactTo::Call(Address::ZERO),
+            ..Default::default()
+        },
+    );
+
+    assert_eq!(insp.get_traces().nodes().first().unwrap().trace.gas_limit, 0);
+
+    // first run inspector
+    let (res, _) = inspect(&mut db, env.clone(), &mut insp).unwrap();
+    assert!(res.result.is_success());
+    assert_eq!(insp.get_traces().nodes().first().unwrap().trace.gas_limit, 1000000);
+
+    // reset the inspector
+    insp.fuse();
+    assert_eq!(insp.get_traces().nodes().first().unwrap().trace.gas_limit, 0);
+
+    // second run inspector after reset
+    let (res, _) = inspect(&mut db, env, &mut insp).unwrap();
+    assert!(res.result.is_success());
+    assert_eq!(insp.get_traces().nodes().first().unwrap().trace.gas_limit, 1000000);
+}


### PR DESCRIPTION
Fixes out of bound error when using `fuse()` in `TracingInspector`.

Error before:
```
index out of bounds: the len is 0 but the index is 0
panicked at src/tracing/arena.rs:54:31:
```

Cause: `CallTraceArena` is initialized using `default()` but when calling `clear()` the default root node is removed.